### PR TITLE
NMB-81 - Numbers only zip code input fix 

### DIFF
--- a/src/components/Inputs/Geocode/AutocompleteField/index.tsx
+++ b/src/components/Inputs/Geocode/AutocompleteField/index.tsx
@@ -65,6 +65,7 @@ const AutocompleteField = ({ showFilters = false,  className, placeholder, defau
                                 type: "text",
                                 className: 'geocode input',
                               })}
+                              onInput={(e) => (e.currentTarget.value = e.currentTarget.value .replace(/[^0-9.]/g, "") .replace(/(\..*?)\..*/g, "$1").replace(/^0[^.]/, "0"))}
                             />
                           </div>
                           


### PR DESCRIPTION
Fix for [NMB-81](https://horizonmedia.atlassian.net/browse/NMB-81), zip code inputs are now only accepting numbers. 

`onInput={(e) => (e.currentTarget.value = e.currentTarget.value .replace(/[^0-9.]/g, "") .replace(/(\..*?)\..*/g, "$1").replace(/^0[^.]/, "0"))}` was used rather than `type="number"` because it doesn't have  cross browser capability. 