### PR TITLE
NMB-103: Final Expense page updates

### DIFF
--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -56,10 +56,14 @@ export const Wrapper = styled.div`
     padding-left: 2.1rem;
     padding-right: 2.1rem;
     padding-top: 2.1rem;
-    position: fixed;
+    position: relative;
   }
 
   @media only screen and (max-width: 600px) {
+    &.takeover-active {
+      position: fixed;
+    }
+    
     &.lp-header {
       margin-top: 81px;
   }

--- a/src/components/Lists/ListItem/styles.ts
+++ b/src/components/Lists/ListItem/styles.ts
@@ -33,7 +33,7 @@ export const Check = styled.div`
   height: 4rem;
   left: -6rem;
   position: absolute;
-  top: 0px;
+  top: -10px;
   width: 4rem;
   z-index: 1;
 
@@ -54,6 +54,7 @@ export const Check = styled.div`
   @media only screen and (max-width: 620px) {
     height: 2.3rem;
     width: 2.3rem;
+    top: -5px;
 
     left: -3.6rem;
 

--- a/src/components/pages/styles/FinalExpenseStyles.ts
+++ b/src/components/pages/styles/FinalExpenseStyles.ts
@@ -159,3 +159,6 @@ export const ListHeading = styled.h4`
     margin-left: -38px;
   }
 `
+export const ListWrapper = styled.div`
+  margin-top: 50px;
+`

--- a/src/components/pages/styles/FinalExpenseStyles.ts
+++ b/src/components/pages/styles/FinalExpenseStyles.ts
@@ -171,4 +171,8 @@ export const ListHeading = styled.h4`
 `
 export const ListWrapper = styled.div`
   margin-top: 50px;
+
+  @media only screen and (max-width: 620px) {
+   margin-top: 40px;
+  }
 `

--- a/src/components/pages/styles/FinalExpenseStyles.ts
+++ b/src/components/pages/styles/FinalExpenseStyles.ts
@@ -81,6 +81,10 @@ export const PageStyles = css`
       width: 100%;
     }
 
+    .hero + div .section {
+      background-color: var(--color-primary-light);
+    }
+
     .hero + .section {
       padding-top: 4rem;
     }

--- a/src/components/pages/styles/FinalExpenseStyles.ts
+++ b/src/components/pages/styles/FinalExpenseStyles.ts
@@ -106,6 +106,12 @@ export const PageStyles = css`
     .button-container {
       min-width: 100%;
     }
+
+    .section:first-of-type .heading h4 {
+      max-width: 100%;
+      padding-left: 20px;
+      padding-right: 0px;
+    }
     
     .hero > img {
       bottom: -8rem;

--- a/src/pages/life-insurance/final-expense-insurance/index.tsx
+++ b/src/pages/life-insurance/final-expense-insurance/index.tsx
@@ -12,7 +12,8 @@ import {
   HeroSubheading,
   SectionOneInner,
   SectionOneInnerContent,
-  ListHeading
+  ListHeading,
+  ListWrapper
 } from "../../../components/pages/styles/FinalExpenseStyles";
 
 // Scripts
@@ -80,10 +81,12 @@ const FinalExpensePage = () => {
           <SectionOneInnerContent>
             <List>
               <ListHeading>{page.finalExpensePageCustomFields.finalExpenseSection1.list.listHeading}</ListHeading>
+              <ListWrapper>
               <ListItem heading={page.finalExpensePageCustomFields.finalExpenseSection1.list.listItem1.text} />
               <ListItem heading={page.finalExpensePageCustomFields.finalExpenseSection1.list.listItem2.text} />
               <ListItem heading={page.finalExpensePageCustomFields.finalExpenseSection1.list.listItem3.text} />
               <ListItem heading={page.finalExpensePageCustomFields.finalExpenseSection1.list.listItem4.text} />
+              </ListWrapper>
             </List>
             <div className="full-rounded" style={{ marginTop: "37px" }}>
               <a href={page?.finalExpensePageCustomFields?.finalExpenseSection1?.button?.link} onClick={routeLink}>


### PR DESCRIPTION
### Summary
The changes made in this pull request rectify the formatting issues in the Final Expense Insurance section on mobile devices. This includes adjusting the background color to match the correct hue on mobile and aligning the checkmark and description text appropriately.

| Before        | After           | 
| ------------- |:-------------:| 
| ![Screenshot 2023-08-09 at 6 22 05 PM](https://github.com/HorizonMedia/HealthMarketWebsite/assets/141367316/f35ffb3f-ecb2-46b1-930e-43546b3333c4) | ![Screenshot 2023-08-09 at 6 29 41 PM](https://github.com/HorizonMedia/HealthMarketWebsite/assets/141367316/1cf859b2-8a16-4de9-9721-70d753d414c1)| 
| ![Screenshot 2023-08-09 at 6 22 17 PM](https://github.com/HorizonMedia/HealthMarketWebsite/assets/141367316/16c56882-20c7-44c7-9855-238c62a245b4)|     ![Screenshot 2023-08-09 at 6 45 51 PM](https://github.com/HorizonMedia/HealthMarketWebsite/assets/141367316/d5faf54a-de41-47e6-b508-975ade9de66c)| 


### Links
Jira Ticket: [https://horizonmedia.atlassian.net/browse/NMB-103](https://horizonmedia.atlassian.net/browse/NMB-103)
Figma: [https://www.figma.com/file/nZKcLyJKOt93ghL9DVbPnU/CLIENT---Landing-Pages?type=design&node-id=2093-32593&mode=design](https://www.figma.com/file/nZKcLyJKOt93ghL9DVbPnU/CLIENT---Landing-Pages?type=design&node-id=2093-32593&mode=design)