### PR TITLE
NMB-285: Placeholder hotfix

### DIFF
--- a/src/components/Inputs/ZipInput.tsx
+++ b/src/components/Inputs/ZipInput.tsx
@@ -28,7 +28,7 @@ const ZipInput = ({zip, setZip}: { zip: string, setZip: (value: string) => void 
         <img
           src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAYAAADEtGw7AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAIQSURBVHgBrVSxUttAEN09ayKnivIFyEUycpo4dYrIhBSp4A8wBTPGFPgPkP8ACsAd8AXQMQN4ZApqTIWgEn9Ah/EMWvY8Olk2Z8kMvBnZu9Luu727fYugQf3McVHQIps2IFrDl0Q9fi72Fu6OYQbgGOGJY6MJ+2y6GTkhPcNK+1/QzYgBoYzV0x8VNPFKQxpO+DYWwG/4zibkEctKDSM64v1aqaqqJva/7s0HJX5Q+gRwqBKJwFs7/740jXh4FPWOs48ItWECJxex39yqhg+6BI71ODauFh9MfCzpYrFx+q1CRuFKVSorhBzUO+UtRNqIK2+1/wbeZIyICkYNRttrwQwoikcvqQzhjy5G8Mo/Rwn9mVop3no3dl0tccoOp52rDnwX98pevyzPZRHb8AbwrSdkO79v7l8RE+G1cqTiYHbqSvzf030VEFFyrtz4mU2v0PDLG6rn+Y70xLE0w9h38xQlFSrFofwI9J1kyB+pfSnToc1JjY5jRwPuz/9BqAKbR7Y1sD4vE5GXVmgR+toLT4bQuKISdJFY3pIIhZsiTBFQ7xM+VSc7any6dZxaTG5DBiQZJZenJ0+3G7A0Dwh52BCswEgACiEfwzZ/L+3O3/6iKDWQeJEBmX7Tt63RYjmQwVMH0rlzgAKWdZXnEudhGvm7iXXkcpgJ+AC0F4Ja+syFgLkPqVhBzmkB9CUS0HoB6Cbcq5bImd0AAAAASUVORK5CYII="
           alt="map location pin image"/>
-        <input type="text" autoComplete="off" className="geocode input" placeholder="Enter Zip Code" value={zip} onChange={onChange} onBlur={onBlur}/>
+        <input type="text" autoComplete="off" className="geocode input" placeholder="Enter ZIP Code" value={zip} onChange={onChange} onBlur={onBlur}/>
         {shouldShowError && <ValidationMessage>Please enter a valid ZIP code</ValidationMessage>}
       </div>
     </>


### PR DESCRIPTION
### Summary
This PR updates the input placeholders to say "ZIP code" instead of "Zip Code".

| Before        | After           | 
| ------------- |:-------------:| 
|<img width="1552" alt="Screenshot 2023-10-02 at 3 00 33 PM" src="https://github.com/HorizonMedia/HealthMarketWebsite/assets/141367316/a2a4f5f1-2412-4697-b3e6-ac371aaa473a">|<img width="1552" alt="Screenshot 2023-10-02 at 3 00 18 PM" src="https://github.com/HorizonMedia/HealthMarketWebsite/assets/141367316/c996dbdf-59c8-481d-b680-47b7b1acfa07">| 



### Links
Jira Ticket: [https://horizonmedia.atlassian.net/browse/NMB-285](https://horizonmedia.atlassian.net/browse/NMB-285)