### PR TITLE
removed the link from the 3 cards in the ACA features

### DIFF
--- a/src/components/Cards/Card/index.tsx
+++ b/src/components/Cards/Card/index.tsx
@@ -30,15 +30,22 @@ interface Props {
   imgStyle?: CSSProperties | undefined,
   background?: String,
   displayImage?: Boolean,
+  nonClickable?: Boolean,
 }
 
 
-const Card: FC<Props> = ({ image = null, icon = null, mobile = null, link = null, title, description = null, children, imgStyle, background, displayImage = true }) => {
+const Card: FC<Props> = ({ image = null, icon = null, mobile = null, link = null, title, description = null, children, imgStyle, background, displayImage = true, nonClickable = false }) => {
   const imageClass = (displayImage) ? ((icon !== null) ? "icon" : "image") : "no-image"
 
   return (
     <>
-      <Wrapper className={`card hide-at-mobile ${imageClass} ${background}`} href={link} onClick={routeLink}>
+      <Wrapper
+        className={`card hide-at-mobile ${imageClass} ${background}`}
+        {...(!nonClickable && {
+          href: link,
+          onClick: routeLink
+        })}
+      >
         {(displayImage && (image !== null || icon !== null)) ? (
           <Header className="card-header">
             <ImgContainer className={(image !== null) ? 'image' : 'icon'}>
@@ -60,7 +67,13 @@ const Card: FC<Props> = ({ image = null, icon = null, mobile = null, link = null
           {children}
         </Content>
       </Wrapper>
-      <MobileWrapper className={`card show-at-mobile ${imageClass} ${background}`} href={link} onClick={routeLink}>
+      <MobileWrapper
+        className={`card show-at-mobile ${imageClass} ${background}`}
+        {...(!nonClickable && {
+          href: link,
+          onClick: routeLink
+        })}
+      >
         <Header className="card-header" onClick={toggleOpenState}>
           {(displayImage && (image !== null || mobile !== null || icon !== null)) ? (
             <ImgContainer className={(image !== null) ? 'image' : 'icon'}>

--- a/src/pages/{wpLandingPage.slug}.tsx
+++ b/src/pages/{wpLandingPage.slug}.tsx
@@ -573,7 +573,8 @@ const LPPage = ({data}: { data: PageInfo }) => {
                               title={card.title}
                               list={(card.list) ? card.list : null}
                               background={card.backgroundColor}
-                              displayImage={card.displayCardImage}>
+                              displayImage={card.displayCardImage}
+                              nonClickable={true}>
                               <p dangerouslySetInnerHTML={{ __html: card.content }} />
                             </Card>
                           )
@@ -609,7 +610,8 @@ const LPPage = ({data}: { data: PageInfo }) => {
                               title={card.title}
                               list={(card.list) ? card.list : null}
                               background={card.backgroundColor}
-                              displayImage={card.displayCardImage}>
+                              displayImage={card.displayCardImage}
+                              nonClickable={true}>
                               <p dangerouslySetInnerHTML={{ __html: card.content }} />
                             </Card>
                           )


### PR DESCRIPTION
For this test, I ensured that the 3 cards in the ACA features doesn't contain a link option. So, it's not causing the page to refresh. In order to achieve this, I created an expression within the Card component that will evaluate a boolean statement. that is false, but added it in for the 3 cards that it'll have "nonClickable={true}" meaning that if a user clicks on the cards, nothing will happen. If a developer chooses to make the cards a link again in the future, all they would need to do is to remove the the "nonClickable={true}" in the wpLandingPage.slug.tsx

JIRA TICKET: https://horizonmedia.atlassian.net/browse/NMB-333